### PR TITLE
Fix equality check always returning false

### DIFF
--- a/lib/compare-xml.rb
+++ b/lib/compare-xml.rb
@@ -195,7 +195,7 @@ module CompareXML
     #
     def compareChildren(n1_set, n2_set, opts, differences, diffchildren = false, status = EQUIVALENT)
       i = 0; j = 0
-      return if opts[:ignore_children]
+      return status if opts[:ignore_children]
       while i < n1_set.length || j < n2_set.length
         if !n1_set[i].nil? && nodeExcluded?(n1_set[i], opts)
           i += 1 # increment counter if left node is excluded
@@ -215,8 +215,8 @@ module CompareXML
           # increment both counters when both nodes have been compared
           i += 1; j += 1
         end
-        status
       end
+      status
     end
 
     ##


### PR DESCRIPTION
The boolean form of equivalent? returned false even for identical input because the comparison result was being discarded. Return the real comparison status so true/false is reported correctly, and make the ignore_children option behave as documented.