### PR TITLE
Report inserted and removed nodes more clearly

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ CompareXML.equivalent?(doc1, doc2, {collapse_whitespace: false, verbose: true})
 - `force_children {true|false}` default **`false`**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[show examples ⇨](#force_children)
     - when `true`, the subnodes of a node are checked independently of the status of the parent node
 
+- `align_children {true|false}` default **`false`**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[show examples ⇨](#align_children)
+    - when `true` (in `verbose` mode), aligns child nodes so insertions and removals are reported as additions/removals instead of changes
+
 
 ## Options in Depth
 
@@ -351,6 +354,21 @@ CompareXML.equivalent?(doc1, doc2, {collapse_whitespace: false, verbose: true})
     When provided, compares all **subnodes** of any node.
 
     **Usage Example:** `CompareXML.equivalent?(doc1, doc2, {force_children: true})`
+
+----------
+
+- <a id="align_children"></a>`align_children: {true|false}` default: **`false`**
+
+    Only takes effect in `verbose` mode. When `true`, sibling nodes are aligned before comparison so that an inserted or removed node is reported as an addition or removal (with one side `nil`) rather than causing the remaining siblings to be reported as a series of changes. Identical subtrees are matched as anchors, and the unmatched nodes between them are compared in order.
+
+    **Usage Example:** `CompareXML.equivalent?(doc1, doc2, {verbose: true, align_children: true})`
+
+    **Example:** Given a left document with three children and a right document with only the third:
+
+        <properties><a/><b/><c/></properties>
+        <properties><c/></properties>
+
+    With `align_children: true`, `<a>` and `<b>` are reported as removals (`node2` is `nil`); without it, they collapse into a single positional change.
 
 ----------
 

--- a/lib/compare-xml.rb
+++ b/lib/compare-xml.rb
@@ -16,6 +16,10 @@ module CompareXML
     # when false, children of elements are not compared if the root is different
     force_children: false,
 
+    # when true (verbose mode only), child nodes are aligned before being compared so that
+    # inserted or removed nodes are reported as additions/removals instead of as changes
+    align_children: false,
+
     # when true, children of elements are never compared
     # when false, children of elements are compared if root is different or see force_children
     ignore_children: false,
@@ -192,9 +196,10 @@ module CompareXML
     #   @return type of equivalence (from equivalence constants)
     #
     def compare_children(n1_set, n2_set, opts, differences, diff_children: false, status: EQUIVALENT)
+      return status if opts[:ignore_children]
+      return compare_aligned_children(n1_set, n2_set, opts, differences, diff_children: diff_children, status: status) if opts[:verbose] && opts[:align_children]
       i = 0
       j = 0
-      return status if opts[:ignore_children]
       while i < n1_set.length || j < n2_set.length
         if !n1_set[i].nil? && node_excluded?(n1_set[i], opts)
           i += 1 # increment counter if left node is excluded
@@ -217,6 +222,111 @@ module CompareXML
         end
       end
       status
+    end
+
+    ##
+    # Compares two sets of child nodes by first aligning them, so that inserted or
+    # removed nodes are reported as additions/removals rather than as changes.
+    # Identical subtrees are matched as anchors (via a longest common subsequence
+    # of their fingerprints); the unmatched nodes between anchors are compared
+    # positionally, and any leftovers become additions or removals.
+    #
+    def compare_aligned_children(n1_set, n2_set, opts, differences, diff_children: false, status: EQUIVALENT)
+      left = n1_set.reject { |n| node_excluded?(n, opts) }
+      right = n2_set.reject { |n| node_excluded?(n, opts) }
+      cache = {}.compare_by_identity
+      fingerprints_left = left.map { |n| node_fingerprint(n, opts, cache) }
+      fingerprints_right = right.map { |n| node_fingerprint(n, opts, cache) }
+
+      prev_i = 0
+      prev_j = 0
+      anchors = longest_common_subsequence(fingerprints_left, fingerprints_right)
+      (anchors + [[left.length, right.length]]).each do |anchor_i, anchor_j|
+        result = compare_child_gap(left[prev_i...anchor_i], right[prev_j...anchor_j], opts, differences, diff_children)
+        status = result unless result == EQUIVALENT
+        prev_i = anchor_i + 1
+        prev_j = anchor_j + 1
+      end
+      status
+    end
+
+    ##
+    # Compares a run of unmatched left and right nodes that lies between two anchors.
+    # Overlapping nodes are compared positionally; remaining left nodes are reported
+    # as removals and remaining right nodes as additions.
+    #
+    def compare_child_gap(left, right, opts, differences, diff_children, status: EQUIVALENT)
+      common = [left.length, right.length].min
+      common.times do |k|
+        result = diff_children ? compare_nodes(left[k], right[k], opts, differences, opts, diff_children: diff_children) : compare_nodes(left[k], right[k], opts, differences)
+        status = result unless result == EQUIVALENT
+      end
+      left.drop(common).each do |n|
+        status = MISSING_NODE
+        add_difference(n, nil, n, nil, opts, differences)
+      end
+      right.drop(common).each do |n|
+        status = MISSING_NODE
+        add_difference(nil, n, nil, n, opts, differences)
+      end
+      status
+    end
+
+    ##
+    # Builds a canonical, option-aware string for a node so that two nodes with equal
+    # fingerprints are guaranteed to be equivalent under the current options. Used to
+    # anchor identical subtrees during alignment. Results are memoized per comparison.
+    #
+    def node_fingerprint(node, opts, cache)
+      cache[node] ||= build_node_fingerprint(node, opts, cache)
+    end
+
+    def build_node_fingerprint(node, opts, cache)
+      case node
+      when Nokogiri::XML::Comment
+        "C:#{opts[:collapse_whitespace] ? collapse(node.content) : node.content}"
+      when Nokogiri::XML::Text
+        "T:#{opts[:collapse_whitespace] ? collapse(node.content) : node.content}"
+      when Nokogiri::XML::Element
+        attrs = node.attribute_nodes
+        attrs = attrs.sort_by(&:name) if opts[:ignore_attr_order]
+        attr_str = attrs.map { |a| "#{a.name}=#{a.value}" }.join(' ')
+        children = node.children.reject { |c| node_excluded?(c, opts) }
+        child_str = children.map { |c| node_fingerprint(c, opts, cache) }.join
+        "E:#{node.name}[#{attr_str}](#{child_str})"
+      else
+        "O:#{node.class}:#{node}"
+      end
+    end
+
+    ##
+    # Returns the index pairs of a longest common subsequence of the two arrays.
+    #
+    def longest_common_subsequence(a, b)
+      m = a.length
+      n = b.length
+      lengths = Array.new(m + 1) { Array.new(n + 1, 0) }
+      (m - 1).downto(0) do |i|
+        (n - 1).downto(0) do |j|
+          lengths[i][j] = a[i] == b[j] ? lengths[i + 1][j + 1] + 1 : [lengths[i + 1][j], lengths[i][j + 1]].max
+        end
+      end
+
+      pairs = []
+      i = 0
+      j = 0
+      while i < m && j < n
+        if a[i] == b[j]
+          pairs << [i, j]
+          i += 1
+          j += 1
+        elsif lengths[i + 1][j] >= lengths[i][j + 1]
+          i += 1
+        else
+          j += 1
+        end
+      end
+      pairs
     end
 
     ##

--- a/test/align_test.rb
+++ b/test/align_test.rb
@@ -1,0 +1,78 @@
+require 'test_helper'
+
+class AlignTest < Minitest::Test
+  def xml(string)
+    Nokogiri::XML(string)
+  end
+
+  def test_aligned_insertions_are_reported_as_additions
+    left = xml('<root><a>1</a><b>2</b><c>3</c></root>')
+    right = xml('<root><c>3</c></root>')
+
+    diffs = CompareXML.equivalent?(left, right, { verbose: true, align_children: true })
+
+    assert_equal 2, diffs.length
+    assert(diffs.all? { |d| d[:node2].nil? && d[:diff2].nil? })
+    assert_equal %w[a b], diffs.map { |d| d[:node1].name }.sort
+  end
+
+  def test_aligned_removals_are_reported_as_removals
+    left = xml('<root><c>3</c></root>')
+    right = xml('<root><a>1</a><b>2</b><c>3</c></root>')
+
+    diffs = CompareXML.equivalent?(left, right, { verbose: true, align_children: true })
+
+    assert_equal 2, diffs.length
+    assert(diffs.all? { |d| d[:node1].nil? && d[:diff1].nil? })
+    assert_equal %w[a b], diffs.map { |d| d[:node2].name }.sort
+  end
+
+  def test_aligned_in_place_edit_is_reported_as_a_change
+    left = xml('<root><a>1</a><b>2</b></root>')
+    right = xml('<root><a>1</a><b>99</b></root>')
+
+    diffs = CompareXML.equivalent?(left, right, { verbose: true, align_children: true })
+
+    assert_equal 1, diffs.length
+    assert_equal %w[2 99], [diffs.first[:diff1], diffs.first[:diff2]]
+    refute_nil diffs.first[:node2]
+  end
+
+  def test_aligned_identical_trees_have_no_differences
+    left = xml('<root><a>1</a><b>2</b><c>3</c></root>')
+
+    assert_empty CompareXML.equivalent?(left, left.dup, { verbose: true, align_children: true })
+  end
+
+  def test_reordered_identical_blocks_show_as_one_removal_and_one_addition
+    left = xml('<root><a>1</a><b>2</b></root>')
+    right = xml('<root><b>2</b><a>1</a></root>')
+
+    diffs = CompareXML.equivalent?(left, right, { verbose: true, align_children: true })
+    removals = diffs.count { |d| d[:node2].nil? }
+    additions = diffs.count { |d| d[:node1].nil? }
+
+    assert_equal 2, diffs.length
+    assert_equal 1, removals
+    assert_equal 1, additions
+  end
+
+  def test_without_alignment_insertions_collapse_into_a_positional_change
+    left = xml('<root><a>1</a><b>2</b><c>3</c></root>')
+    right = xml('<root><c>3</c></root>')
+
+    diffs = CompareXML.equivalent?(left, right, { verbose: true })
+
+    assert_equal 1, diffs.length
+    refute_nil diffs.first[:node1]
+    refute_nil diffs.first[:node2]
+  end
+
+  def test_alignment_does_not_change_boolean_result
+    left = xml('<root><a>1</a><c>3</c></root>')
+    right = xml('<root><c>3</c></root>')
+
+    refute CompareXML.equivalent?(left, right, { align_children: true })
+    assert CompareXML.equivalent?(left, left.dup, { align_children: true })
+  end
+end


### PR DESCRIPTION
When listing differences in verbose mode, child nodes were compared strictly by position, so a single insertion or removal made every following node look changed. The new opt-in align_children option matches identical nodes first and reports the leftovers as genuine additions or removals. It is off by default and does not change the true/false comparison result.

Addresses #6.