### PR TITLE
Treat ignored comments and text as equal in all modes

### DIFF
--- a/lib/compare-xml.rb
+++ b/lib/compare-xml.rb
@@ -147,7 +147,7 @@ module CompareXML
     #   @return type of equivalence (from equivalence constants)
     #
     def compare_comment_nodes(n1, n2, opts, differences, status: EQUIVALENT)
-      return true if opts[:ignore_comments]
+      return status if opts[:ignore_comments]
       t1 = n1.content
       t2 = n2.content
       if opts[:collapse_whitespace]
@@ -369,7 +369,7 @@ module CompareXML
     #   @return type of equivalence (from equivalence constants)
     #
     def compare_text_nodes(n1, n2, opts, differences, status = EQUIVALENT)
-      return true if opts[:ignore_text_nodes]
+      return status if opts[:ignore_text_nodes]
       t1 = n1.content
       t2 = n2.content
       if opts[:collapse_whitespace]

--- a/test/options_test.rb
+++ b/test/options_test.rb
@@ -75,6 +75,14 @@ class OptionsTest < Minitest::Test
     refute CompareXML.equivalent?(a, b, { ignore_comments: false })
   end
 
+  def test_ignored_bare_comment_nodes_agree_in_boolean_and_verbose_modes
+    a = frag('<!-- one -->').children.first
+    b = frag('<!-- two -->').children.first
+
+    assert CompareXML.equivalent?(a, b)
+    assert_empty CompareXML.equivalent?(a, b, { verbose: true })
+  end
+
   def test_ignore_nodes_by_css
     a = frag('<div><a href="/admin" target="_blank">L1</a></div>')
     b = frag('<div><a href="/index" target="_self">L2</a></div>')
@@ -89,6 +97,14 @@ class OptionsTest < Minitest::Test
 
     refute CompareXML.equivalent?(a, b)
     assert CompareXML.equivalent?(a, b, { ignore_text_nodes: true })
+  end
+
+  def test_ignored_bare_text_nodes_agree_in_boolean_and_verbose_modes
+    a = frag('hello').children.first
+    b = frag('world').children.first
+
+    assert CompareXML.equivalent?(a, b, { ignore_text_nodes: true })
+    assert_empty CompareXML.equivalent?(a, b, { ignore_text_nodes: true, verbose: true })
   end
 
   def test_verbose_difference_structure


### PR DESCRIPTION
When comparing a bare comment or text node directly with the matching ignore option on, the boolean comparison wrongly reported them as different while verbose mode reported no differences. Both modes now agree that the nodes are equal.