### PR TITLE
Keep attribute differences when force_children is enabled

### DIFF
--- a/lib/compare-xml.rb
+++ b/lib/compare-xml.rb
@@ -348,6 +348,7 @@ module CompareXML
       if n1.name == n2.name
         result = compare_attribute_sets(n1, n2, n1.attribute_nodes, n2.attribute_nodes, opts, differences)
         return result unless result == EQUIVALENT || opts[:force_children] == true
+        status = result unless result == EQUIVALENT
         result = diff_children ? compare_children(n1.children, n2.children, child_opts, differences, diff_children: diff_children) : compare_children(n1.children, n2.children, opts, differences)
         status = result unless result == EQUIVALENT
       else

--- a/test/options_test.rb
+++ b/test/options_test.rb
@@ -113,6 +113,14 @@ class OptionsTest < Minitest::Test
     assert_equal 2, CompareXML.equivalent?(a, b, { verbose: true, force_children: true }).length
   end
 
+  def test_force_children_still_reports_attribute_difference_when_children_match
+    a = frag('<div class="a"><p>X</p></div>')
+    b = frag('<div class="b"><p>X</p></div>')
+
+    refute CompareXML.equivalent?(a, b, { force_children: true })
+    assert CompareXML.equivalent?(a, frag('<div class="a"><p>X</p></div>'), { force_children: true })
+  end
+
   def test_ignore_children
     a = frag('<div><a href="/a">L1</a></div>')
     b = frag('<div><a href="/b">L2</a></div>')


### PR DESCRIPTION
With force_children on, an attribute difference was discarded once the child comparison ran, so two elements with different attributes but identical children were reported as equal. The attribute result is now preserved, so the difference is still reported.