### PR TITLE
Report all attribute differences in verbose mode

### DIFF
--- a/lib/compare-xml.rb
+++ b/lib/compare-xml.rb
@@ -472,7 +472,7 @@ module CompareXML
       [a1_set.length, a2_set.length].max.times do |i|
         result = compare_attributes(n1, n2, a1_set[i], a2_set[i], opts, differences)
         status = result unless result == EQUIVALENT
-        break unless status == EQUIVALENT
+        break unless status == EQUIVALENT || opts[:verbose]
       end
       status
     end

--- a/test/options_test.rb
+++ b/test/options_test.rb
@@ -19,6 +19,13 @@ class OptionsTest < Minitest::Test
     refute CompareXML.equivalent?(a, b, { ignore_attr_order: false })
   end
 
+  def test_unsorted_attribute_comparison_reports_all_differences_in_verbose
+    a = frag('<a x="1" y="1">L</a>')
+    b = frag('<a x="2" y="2">L</a>')
+
+    assert_equal 2, CompareXML.equivalent?(a, b, { ignore_attr_order: false, verbose: true }).length
+  end
+
   def test_ignore_attr_content
     a = frag('<a href="/admin" id="button_1" class="blue button">L</a>')
     b = frag('<a href="/admin" id="button_2" class="info button">L</a>')


### PR DESCRIPTION
When attribute order was significant, verbose mode stopped at the first differing attribute instead of listing them all. It now collects every attribute difference, matching the behaviour used when attribute order is ignored.