### PR TITLE
Match ignored attribute names exactly, with regexp support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -82,3 +82,8 @@ Style/MutableConstant:
 # trailing options hash gets absorbed into keywords.
 Style/OptionalBooleanParameter:
   Enabled: false
+
+# Attribute-name matchers are intentionally compared with === so that a
+# String matches exactly while a Regexp matches as a pattern.
+Style/CaseEquality:
+  Enabled: false

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ CompareXML.equivalent?(doc1, doc2, {collapse_whitespace: false, verbose: true})
 - `ignore_attrs: [css_selector1, css_selector1, ...]` default: **`[]`**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[show examples ⇨](#ignore_attrs)
     - when provided, ignores specific *attributes* using [CSS selectors](http://www.w3schools.com/cssref/css_selectors.asp)
 
-- `ignore_attrs_by_name: [string1, string2, ...]` default: **`[]`**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[show examples ⇨](#ignore_attrs_by_name)
-    - when provided, ignores specific *attributes* using [String]
+- `ignore_attrs_by_name: [matcher1, matcher2, ...]` default: **`[]`**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[show examples ⇨](#ignore_attrs_by_name)
+    - when provided, ignores *attributes* whose name matches a `String` (exact) or `Regexp` (pattern)
 
 - `ignore_comments: {true|false}` default: **`true`**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[show examples ⇨](#ignore_comments)
     - when `true`, ignores comments, such as `<!-- comment -->`
@@ -204,16 +204,21 @@ CompareXML.equivalent?(doc1, doc2, {collapse_whitespace: false, verbose: true})
 
 ----------
 
-- <a id="ignore_attrs_by_name"></a>`ignore_attrs_by_name: [string1, string2, ...]` default: **`false`**
+- <a id="ignore_attrs_by_name"></a>`ignore_attrs_by_name: [matcher1, matcher2, ...]` default: **`[]`**
 
-    When provided, ignores all **attributes** which name is specified in the string array.
+    When provided, ignores all **attributes** whose name matches one of the given matchers. A `String` matches the attribute name exactly, while a `Regexp` matches it as a pattern.
 
-     **Usage Example:** `CompareXML.equivalent?(doc1, doc2, {ignore_attrs_by_name: ['target'])`
+     **Usage Example:** `CompareXML.equivalent?(doc1, doc2, {ignore_attrs_by_name: ['target', /^data-/]})`
 
     **Example:** With `ignore_attrs_by_name: ['target', 'rel']` the following HTML strings are considered equal:
 
         <a href="/admin" class="button" target="_blank">Link</a>
         <a href="/admin" class="button" target="_self" rel="nofollow">Link</a>
+
+    **Example:** With `ignore_attrs_by_name: [/^data-/]` the following HTML strings are considered equal:
+
+        <div data-id="1" data-role="row">Link</div>
+        <div data-id="2" data-role="cell">Link</div>
 
     An ignored attribute does not need to be present on both elements. With `ignore_attrs_by_name: ['class']` the following HTML strings are considered equal:
 

--- a/lib/compare-xml.rb
+++ b/lib/compare-xml.rb
@@ -538,13 +538,16 @@ module CompareXML
     # check is one-sided, so an attribute is dropped even when its counterpart is missing
     # on the other element.
     #
+    # Name matchers are compared with +===+: a String matches the attribute name exactly,
+    # while a Regexp matches it as a pattern.
+    #
     #   @param [Nokogiri::XML::Attr] attr the attribute being tested
     #   @param [Hash] opts user-overridden options
     #
     #   @return true if excluded, false otherwise
     #
     def attribute_excluded?(attr, opts)
-      return true if opts[:ignore_attrs_by_name].any? { |name| attr.name.include?(name) }
+      return true if opts[:ignore_attrs_by_name].any? { |matcher| matcher === attr.name }
       return true if opts[:ignore_attr_content].any? { |content| attr.value.include?(content) }
 
       opts[:ignore_attrs].any? { |css| css.include?(attr.name) && attr.parent.xpath('../*').css(css).include?(attr.parent) }

--- a/test/options_test.rb
+++ b/test/options_test.rb
@@ -58,6 +58,22 @@ class OptionsTest < Minitest::Test
     assert CompareXML.equivalent?(a, b, { ignore_attrs_by_name: ['class'] })
   end
 
+  def test_ignore_attrs_by_name_matches_strings_exactly
+    a = frag('<div data-id="1"></div>')
+    b = frag('<div data-id="2"></div>')
+
+    refute CompareXML.equivalent?(a, b, { ignore_attrs_by_name: ['id'] })
+    assert CompareXML.equivalent?(a, b, { ignore_attrs_by_name: ['data-id'] })
+  end
+
+  def test_ignore_attrs_by_name_matches_regexps_as_patterns
+    a = frag('<div data-id="1" data-role="row"></div>')
+    b = frag('<div data-id="2" data-role="cell"></div>')
+
+    refute CompareXML.equivalent?(a, b)
+    assert CompareXML.equivalent?(a, b, { ignore_attrs_by_name: [/^data-/] })
+  end
+
   def test_ignore_attrs_by_css_when_attribute_missing_on_one_side
     a = frag('<div><a href="/admin" target="_blank">L</a></div>')
     b = frag('<div><a href="/admin">L</a></div>')


### PR DESCRIPTION
The ignore_attrs_by_name option matched attribute names by substring, so asking to ignore "id" also dropped "data-id" or "grid". Names are now matched with ===, so a String matches exactly and a Regexp matches as a pattern, making broad matches explicit instead of accidental.