### PR TITLE
Slim down packaged gem and tidy project metadata

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    name: RuboCop & ESLint
+    name: RuboCop
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Lint Status](https://github.com/vkononov/compare-xml/actions/workflows/lint.yml/badge.svg)](https://github.com/vkononov/compare-xml/actions/workflows/lint.yml)
 [![Test Status](https://github.com/vkononov/compare-xml/actions/workflows/test.yml/badge.svg)](https://github.com/vkononov/compare-xml/actions/workflows/test.yml)
 
-CompareXML is a fast, lightweight and feature-rich tool that will solve your XML/HTML comparison or diffing needs. its purpose is to compare two instances of `Nokogiri::XML::Node` or `Nokogiri::XML::NodeSet` for equality or equivalency.
+CompareXML is a fast, lightweight and feature-rich tool that will solve your XML/HTML comparison or diffing needs. Its purpose is to compare two instances of `Nokogiri::XML::Node` or `Nokogiri::XML::NodeSet` for equality or equivalency.
 
 [!["Buy Me A Coffee"](https://www.buymeacoffee.com/assets/img/custom_images/yellow_img.png)](https://www.buymeacoffee.com/vkononov)
 
@@ -298,7 +298,7 @@ CompareXML.equivalent?(doc1, doc2, {collapse_whitespace: false, verbose: true})
 
     **Example:** When `true` given the following HTML strings:
 
-    ![diffing](https://github.com/vkononov/compare-xml/raw/master/img/diffing.png)
+    ![diffing](https://github.com/vkononov/compare-xml/raw/main/img/diffing.png)
 
     `CompareXML.equivalent?(doc1, doc2, {verbose: true})` will produce an array shown below.
 

--- a/bin/lint
+++ b/bin/lint
@@ -14,7 +14,7 @@ RUBOCOP_CONFIG=.rubocop.yml
 test -e ${RUBOCOP_CONFIG} || { echo -e "${ERROR_COLOR}"ERROR: ${RUBOCOP_CONFIG} not found."${RESET_COLOR}"; exit 1; }
 
 # Running linters
-echo -e "${HIGHLIGHT_COLOR}"Linting Ruby on Rails using RuboCop..."${RESET_COLOR}"
+echo -e "${HIGHLIGHT_COLOR}"Linting Ruby using RuboCop..."${RESET_COLOR}"
 if [[ "$1" == "--no-fix" ]]; then
         bundle exec rubocop || { valid=false; }
 else

--- a/compare-xml.gemspec
+++ b/compare-xml.gemspec
@@ -1,29 +1,38 @@
-lib = File.expand_path('lib', __dir__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'compare-xml/version'
+require_relative 'lib/compare-xml/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = 'compare-xml'
-  spec.version       = CompareXML::VERSION
-  spec.authors       = ['Vadim Kononov']
-  spec.email         = ['vadim@poetic.com']
+  spec.name = 'compare-xml'
+  spec.version = CompareXML::VERSION
+  spec.authors = ['Vadim Kononov']
+  spec.email = ['vadim@konoson.com']
 
-  spec.summary       = 'A customizable tool that compares two instances of Nokogiri::XML::Node for equality or equivalency.'
-  spec.description   = 'CompareXML is a fast, lightweight and feature-rich tool that will solve your XML/HTML comparison or diffing needs. its purpose is to compare two instances of Nokogiri::XML::Node or Nokogiri::XML::NodeSet for equality or equivalency.'
-  spec.homepage      = 'https://github.com/vkononov/compare-xml'
-  spec.license       = 'MIT'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.4.0')
+  spec.summary = 'A customizable tool that compares two instances of Nokogiri::XML::Node for equality or equivalency.'
+  spec.description = 'CompareXML is a fast, lightweight and feature-rich tool that will solve your XML/HTML comparison or diffing needs. its purpose is to compare two instances of Nokogiri::XML::Node or Nokogiri::XML::NodeSet for equality or equivalency.'
+  spec.homepage = 'https://github.com/vkononov/compare-xml'
+  spec.license = 'MIT'
+  spec.required_ruby_version = '>= 2.4.0'
 
-  spec.files = Dir.chdir(File.expand_path(__dir__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(example|test|spec|features)/}) }
+  spec.metadata['homepage_uri'] = spec.homepage
+  spec.metadata['source_code_uri'] = spec.homepage
+  spec.metadata['changelog_uri'] = "#{spec.homepage}/releases"
+
+  # Specify which files should be added to the gem when it is released.
+  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  gemspec = File.basename(__FILE__)
+  spec.files = IO.popen(%w[git ls-files -z], chdir: __dir__, err: IO::NULL) do |ls|
+    ls.readlines("\x0", chomp: true).reject do |f|
+      (f == gemspec) ||
+        f.start_with?(*%w[bin/ test/ spec/ features/ templates/ .git Gemfile Rakefile .rubocop.yml img/])
+    end
   end
-  spec.bindir        = 'exe'
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.bindir = 'exe'
+  spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'nokogiri'
+  # Uncomment to register a new dependency of your gem
+  spec.add_dependency 'nokogiri', '>= 1.6'
 
-  spec.metadata = {
-    'rubygems_mfa_required' => 'true'
-  }
+  # For more information and examples about making a new gem, check out our
+  # guide at: https://bundler.io/guides/creating_gem.html
+  spec.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
Package only the files needed at runtime by excluding dev and doc files, and set a minimum nokogiri version so compatibility is explicit. Also point the README diagram at the main branch and correct the lint job name and message, which still referenced tools the project does not use.