### PR TITLE
Ship only runtime files in the published gem

### DIFF
--- a/compare-xml.gemspec
+++ b/compare-xml.gemspec
@@ -16,13 +16,13 @@ Gem::Specification.new do |spec|
   spec.metadata['source_code_uri'] = spec.homepage
   spec.metadata['changelog_uri'] = "#{spec.homepage}/releases"
 
-  # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  gemspec = File.basename(__FILE__)
+  # Ship only what the gem needs at runtime: the library code plus the license
+  # and readme. Using an allowlist keeps tests, tooling, CI config, and images
+  # out of the package even as new development files are added over time.
+  root_files = %w[LICENSE.txt README.md]
   spec.files = IO.popen(%w[git ls-files -z], chdir: __dir__, err: IO::NULL) do |ls|
-    ls.readlines("\x0", chomp: true).reject do |f|
-      (f == gemspec) ||
-        f.start_with?(*%w[bin/ test/ spec/ features/ templates/ .git Gemfile Rakefile .rubocop.yml img/])
+    ls.readlines("\x0", chomp: true).select do |f|
+      f.start_with?('lib/') || root_files.include?(f)
     end
   end
   spec.bindir = 'exe'


### PR DESCRIPTION
Switch the gemspec to an allowlist so the released package contains just the library code, license, and readme. This keeps tests, tooling, CI config, and images out of the gem even as new development files are added.